### PR TITLE
Change build method

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project contains Java classes and the corresponding JNI C++ code.
 Build and package the Java classes:
 
 ```bash
-mvn clean compile package
+mvn clean install
 ```
 
 Build the C++ JNI code


### PR DESCRIPTION
Use mvn clean install instead of mvn clean compile package as it is more
convenient for further uses i.e. normal scopes can be used when adding
soda-java as a dependency to other POMs.
